### PR TITLE
Fix PendingIntent flags and restore database helper safely

### DIFF
--- a/smali/com/hp/vd/AlarmRoutine.smali
+++ b/smali/com/hp/vd/AlarmRoutine.smali
@@ -174,7 +174,7 @@
 
     const/4 v2, 0x0
 
-    const/high16 v3, 0x8000000
+    const v3, 0xc000000
 
     invoke-static {v1, v2, v0, v3}, Landroid/app/PendingIntent;->getBroadcast(Landroid/content/Context;ILandroid/content/Intent;I)Landroid/app/PendingIntent;
 

--- a/smali/com/hp/vd/module/ModuleAbstract.smali
+++ b/smali/com/hp/vd/module/ModuleAbstract.smali
@@ -509,6 +509,16 @@
     return-void
 .end method
 
+.method public resetDao()V
+    .locals 1
+
+    const/4 v0, 0x0
+
+    iput-object v0, p0, Lcom/hp/vd/module/ModuleAbstract;->dao:Lcom/j256/ormlite/dao/Dao;
+
+    return-void
+.end method
+
 .method public setDataReadLimit(Ljava/lang/Integer;)Z
     .locals 3
 

--- a/smali/com/hp/vd/module/synchronizer/file/SynchronizationRunnable.smali
+++ b/smali/com/hp/vd/module/synchronizer/file/SynchronizationRunnable.smali
@@ -109,6 +109,17 @@
     invoke-virtual {v2}, Lcom/hp/vd/data/persistency/DatabaseHelper;->getWritableDatabase()Landroid/database/sqlite/SQLiteDatabase;
 
     :cond_2
+    instance-of v2, p1, Lcom/hp/vd/module/ModuleAbstract;
+
+    if-eqz v2, :cond_3
+
+    move-object v2, p1
+
+    check-cast v2, Lcom/hp/vd/module/ModuleAbstract;
+
+    invoke-virtual {v2}, Lcom/hp/vd/module/ModuleAbstract;->resetDao()V
+
+    :cond_3
     invoke-interface {p1}, Lcom/hp/vd/module/IModule;->getDao()Lcom/j256/ormlite/dao/Dao;
 
     move-result-object v0


### PR DESCRIPTION
## Summary
- mark the startup alarm PendingIntent as immutable to satisfy Android 12+ requirements while retaining update behavior
- add a DAO reset helper on ModuleAbstract and invoke it before reopening ORMLite DAOs to avoid stale references after the database helper is closed

## Testing
- not run (smali-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d00f11314c8328839279f368ec47ae